### PR TITLE
使用MimeType 类库判定文件类型，避免穷举不到位的情况

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/utils/FileUtil.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/FileUtil.java
@@ -8,6 +8,8 @@ import cn.hutool.poi.excel.ExcelUtil;
 import cn.hutool.poi.excel.ExcelWriter;
 import me.zhengjie.exception.BadRequestException;
 import org.springframework.web.multipart.MultipartFile;
+
+import javax.activation.MimetypesFileTypeMap;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
@@ -231,7 +233,12 @@ public class FileUtil extends cn.hutool.core.io.FileUtil {
             return "视频";
         } else return "其他";
     }
-
+    public static String getFileTypeByMimeType(String type) {
+//        URLConnection.guessContentTypeFromName("." + type)
+//        way 2 new MimetypesFileTypeMap().getContentType("."+ "txt")
+        String mimeType = new MimetypesFileTypeMap().getContentType("." + type);
+         return mimeType.split("\\/")[0];
+    }
     public static void checkSize(long maxSize, long size) {
         if(size > (maxSize * 1024 * 1024)){
             throw new BadRequestException("文件超出规定大小");

--- a/eladmin-tools/src/main/java/me/zhengjie/service/impl/LocalStorageServiceImpl.java
+++ b/eladmin-tools/src/main/java/me/zhengjie/service/impl/LocalStorageServiceImpl.java
@@ -63,7 +63,7 @@ public class LocalStorageServiceImpl implements LocalStorageService {
     public LocalStorageDTO create(String name, MultipartFile multipartFile) {
         FileUtil.checkSize(maxSize, multipartFile.getSize());
         String suffix = FileUtil.getExtensionName(multipartFile.getOriginalFilename());
-        String type = FileUtil.getFileType(suffix);
+        String type = FileUtil.getFileTypeByMimeType(suffix);
         File file = FileUtil.upload(multipartFile, path + type +  File.separator);
         try {
             name = StringUtils.isBlank(name) ? FileUtil.getFileNameNoEx(multipartFile.getOriginalFilename()) : name;


### PR DESCRIPTION
Getting A File's Mime Type In Java
//        URLConnection.guessContentTypeFromName("." + type)
//        way 2 new MimetypesFileTypeMap().getContentType("."+ "txt")

website: https://www.baeldung.com/java-file-mime-type