### PR TITLE
修复一个缺少break语句的bug

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/utils/QueryHelp.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/QueryHelp.java
@@ -101,6 +101,7 @@ public class QueryHelp {
                         case RIGHT_LIKE:
                             list.add(cb.like(getExpression(attributeName,join,root)
                                     .as(String.class), val.toString() + "%"));
+                            break;
                         case IN:
                             if (CollUtil.isNotEmpty((Collection<Long>)val)) {
                                 list.add(getExpression(attributeName,join,root).in((Collection<Long>) val));


### PR DESCRIPTION
QueryHelp类里，switch到RIGHT_LIKE时缺少break语句。
之前提错提到master了，现在改提到2.4dev分支了