### PR TITLE
Add Index on dict.name

### DIFF
--- a/sql/eladmin.sql
+++ b/sql/eladmin.sql
@@ -103,7 +103,8 @@ CREATE TABLE `dict`  (
   `name` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL COMMENT '字典名称',
   `remark` varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL COMMENT '描述',
   `create_time` datetime NULL DEFAULT NULL COMMENT '创建日期',
-  PRIMARY KEY (`id`) USING BTREE
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `idx_name` (`name`)
 ) ENGINE = InnoDB AUTO_INCREMENT = 6 CHARACTER SET = utf8 COLLATE = utf8_general_ci COMMENT = '数据字典' ROW_FORMAT = Compact;
 
 -- ----------------------------


### PR DESCRIPTION
Adding index on table `dict` column `name` might speed up the underlying query issued via `DictService#queryAll(DictQueryCriteria, Pageable)`. See #255 