### PR TITLE
当前用户如果没有任何权限时，在输入用户名后，刷新验证码会抛IllegalArgumentException

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/security/TokenProvider.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/security/TokenProvider.java
@@ -1,5 +1,6 @@
 package me.zhengjie.modules.security.security;
 
+import cn.hutool.core.util.ObjectUtil;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -16,6 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.stream.Collectors;
 
@@ -63,10 +65,13 @@ public class TokenProvider implements InitializingBean {
          .parseClaimsJws(token)
          .getBody();
 
+      // fix bug: 当前用户如果没有任何权限时，在输入用户名后，刷新验证码会抛IllegalArgumentException
+       Object authoritiesStr = claims.get(AUTHORITIES_KEY);
       Collection<? extends GrantedAuthority> authorities =
-         Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+              ObjectUtil.isNotEmpty(authoritiesStr) ?
+       Arrays.stream(authoritiesStr.toString().split(","))
             .map(SimpleGrantedAuthority::new)
-            .collect(Collectors.toList());
+            .collect(Collectors.toList()) : Collections.emptyList();
 
       User principal = new User(claims.getSubject(), "", authorities);
 

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
@@ -93,8 +93,8 @@ public class UserServiceImpl implements UserService {
     public void update(User resources) {
         User user = userRepository.findById(resources.getId()).orElseGet(User::new);
         ValidationUtil.isNull(user.getId(),"User","id",resources.getId());
-        User user1 = userRepository.findByUsername(user.getUsername());
-        User user2 = userRepository.findByEmail(user.getEmail());
+        User user1 = userRepository.findByUsername(resources.getUsername());
+        User user2 = userRepository.findByEmail(resources.getEmail());
 
         if(user1 !=null&&!user.getId().equals(user1.getId())){
             throw new EntityExistException(User.class,"username",resources.getUsername());


### PR DESCRIPTION
**复现步骤：**
新用户拥有一个角色，该角色的permission项为空且roles_menus没有与该角色的对应值，使用该用户去登录，后台会抛出IllegalArgumentException，并且之后无法正常刷新验证码

**原因：**
`SimpleGrantedAuthority::new`构造函数会判断是否为空，为空则抛出IllegalArgumentException

**修复思路：**
增加为空校验，为空返回空list

**修复结果：**
可以正常登陆，正常刷新验证码