### PR TITLE
One method name is not clear

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/DictController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/DictController.java
@@ -55,7 +55,7 @@ public class DictController {
     @ApiOperation("查询字典")
     @GetMapping
     @PreAuthorize("@el.check('dict:list')")
-    public ResponseEntity<Object> getDicts(DictQueryCriteria resources, Pageable pageable){
+    public ResponseEntity<Object> getByQuery(DictQueryCriteria resources, Pageable pageable){
         return new ResponseEntity<>(dictService.queryAll(resources,pageable),HttpStatus.OK);
     }
 


### PR DESCRIPTION
The original method name is not clear enough to describe the work of the method. In fact, this method is used to search all matched results. But the original name "getDicts" may make developers misunderstand this method that is used to create dictionaries or some other works. I just would like to make it clear about this problem.