### PR TITLE
修复[系统工具]-[代码生成]分页功能

### DIFF
--- a/eladmin-generator/src/main/java/me/zhengjie/rest/GeneratorController.java
+++ b/eladmin-generator/src/main/java/me/zhengjie/rest/GeneratorController.java
@@ -24,6 +24,7 @@ import me.zhengjie.service.GenConfigService;
 import me.zhengjie.service.GeneratorService;
 import me.zhengjie.utils.PageUtil;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -55,10 +56,8 @@ public class GeneratorController {
 
     @ApiOperation("查询数据库数据")
     @GetMapping(value = "/tables")
-    public ResponseEntity<Object> queryTables(@RequestParam(defaultValue = "") String name,
-                                    @RequestParam(defaultValue = "0")Integer page,
-                                    @RequestParam(defaultValue = "10")Integer size){
-        int[] startEnd = PageUtil.transToStartEnd(page, size);
+    public ResponseEntity<Object> queryTables(@RequestParam(defaultValue = "") String name, Pageable pageable) {
+        int[] startEnd = PageUtil.transToStartEnd(pageable.getPageNumber() + 1, pageable.getPageSize());
         return new ResponseEntity<>(generatorService.getTables(name,startEnd), HttpStatus.OK);
     }
 

--- a/eladmin-generator/src/main/java/me/zhengjie/service/impl/GeneratorServiceImpl.java
+++ b/eladmin-generator/src/main/java/me/zhengjie/service/impl/GeneratorServiceImpl.java
@@ -86,8 +86,9 @@ public class GeneratorServiceImpl implements GeneratorService {
             Object[] arr = (Object[]) obj;
             tableInfos.add(new TableInfo(arr[0], arr[1], arr[2], arr[3], ObjectUtil.isNotEmpty(arr[4]) ? arr[4] : "-"));
         }
-        Query query1 = em.createNativeQuery("SELECT COUNT(*) from information_schema.tables where table_schema = (select database())");
-        Object totalElements = query1.getSingleResult();
+        Query totalQuery = em.createNativeQuery("SELECT COUNT(*) from information_schema.tables where table_schema = (select database()) and table_name like ? ");
+        totalQuery.setParameter(1, StringUtils.isNotBlank(name) ? ("%" + name + "%") : "%%");
+        Object totalElements = totalQuery.getSingleResult();
         return PageUtil.toPage(tableInfos, totalElements);
     }
 


### PR DESCRIPTION
起因：分页参数size和业务字段冲突，造成业务列表分页功能不可用。
解决方案：
修改eladmin-web/src/components/Crud/crud.js
```
/**
     * 获取查询参数
     */
    getQueryParams: function() {
...
return {
        pageNumber: crud.page.page - 1,
        pageSize: crud.page.size,
        sort: crud.sort,
        ...crud.query,
        ...crud.params
      }
...
```
修改eladmin/eladmin-system/src/main/resources/config/application.yml
```
spring:
  data:
    web:
      pageable:
        page-parameter: pageNumber
        size-parameter: pageSize
```
以上方案是进行框架、组件级别的修改，目前没有发现通用功能被影响。
但在[系统工具]-[代码生成]页面，发现分页的实现，是用page/size进行接收参数。
另外通过表名进行模糊搜索后，总条数不正确。

问题点：
1、分页参数和框架不一致，造成不通用。
2、通过表名进行模糊搜索后，总条数不正确。

以上代码解决该问题！