### PR TITLE
修改sys_dict_detail数据表的value字段数据类型为smallint

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserDetailsServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserDetailsServiceImpl.java
@@ -72,7 +72,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
             if (user == null) {
                 throw new UsernameNotFoundException("");
             } else {
-                if (!user.getEnabled()) {
+                if (!(user.getEnabled() == 1)) {
                     throw new BadRequestException("账号未激活！");
                 }
                 jwtUserDto = new JwtUserDto(

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/service/dto/JwtUserDto.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/service/dto/JwtUserDto.java
@@ -77,6 +77,6 @@ public class JwtUserDto implements UserDetails {
     @Override
     @JsonIgnore
     public boolean isEnabled() {
-        return user.getEnabled();
+        return user.getEnabled() == 1;
     }
 }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/Dept.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/Dept.java
@@ -58,7 +58,7 @@ public class Dept extends BaseEntity implements Serializable {
 
     @NotNull
     @ApiModelProperty(value = "是否启用")
-    private Boolean enabled;
+    private Integer enabled;
 
     @ApiModelProperty(value = "上级部门")
     private Long pid;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/DictDetail.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/DictDetail.java
@@ -49,7 +49,7 @@ public class DictDetail extends BaseEntity implements Serializable {
     private String label;
 
     @ApiModelProperty(value = "字典值")
-    private String value;
+    private Integer value;
 
     @ApiModelProperty(value = "排序")
     private Integer dictSort = 999;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/Job.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/Job.java
@@ -54,7 +54,7 @@ public class Job extends BaseEntity implements Serializable {
 
     @NotNull
     @ApiModelProperty(value = "是否启用")
-    private Boolean enabled;
+    private Integer enabled;
 
     @Override
     public boolean equals(Object o) {

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/User.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/domain/User.java
@@ -96,7 +96,7 @@ public class User extends BaseEntity implements Serializable {
 
     @NotNull
     @ApiModelProperty(value = "是否启用")
-    private Boolean enabled;
+    private Integer enabled;
 
     @ApiModelProperty(value = "是否为admin账号", hidden = true)
     private Boolean isAdmin = false;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/DeptDto.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/DeptDto.java
@@ -35,7 +35,7 @@ public class DeptDto extends BaseDTO implements Serializable {
 
     private String name;
 
-    private Boolean enabled;
+    private Integer enabled;
 
     private Integer deptSort;
 

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/DeptQueryCriteria.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/DeptQueryCriteria.java
@@ -33,7 +33,7 @@ public class DeptQueryCriteria{
     private String name;
 
     @Query
-    private Boolean enabled;
+    private Integer enabled;
 
     @Query
     private Long pid;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/DictDetailDto.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/DictDetailDto.java
@@ -35,7 +35,7 @@ public class DictDetailDto extends BaseDTO implements Serializable {
 
     private String label;
 
-    private String value;
+    private Integer value;
 
     private Integer dictSort;
 }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/JobDto.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/JobDto.java
@@ -38,10 +38,10 @@ public class JobDto extends BaseDTO implements Serializable {
 
     private String name;
 
-    private Boolean enabled;
+    private Integer enabled;
 
     public JobDto(String name, Boolean enabled) {
         this.name = name;
-        this.enabled = enabled;
+        this.enabled = enabled ? 1 : 0;
     }
 }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/JobQueryCriteria.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/JobQueryCriteria.java
@@ -33,7 +33,7 @@ public class JobQueryCriteria {
     private String name;
 
     @Query
-    private Boolean enabled;
+    private Integer enabled;
 
     @Query(type = Query.Type.BETWEEN)
     private List<Timestamp> createTime;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/UserDto.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/UserDto.java
@@ -58,7 +58,7 @@ public class UserDto extends BaseDTO implements Serializable {
     @JsonIgnore
     private String password;
 
-    private Boolean enabled;
+    private Integer enabled;
 
     @JsonIgnore
     private Boolean isAdmin = false;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/UserQueryCriteria.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/dto/UserQueryCriteria.java
@@ -40,7 +40,7 @@ public class UserQueryCriteria implements Serializable {
     private String blurry;
 
     @Query
-    private Boolean enabled;
+    private Integer enabled;
 
     private Long deptId;
 

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
@@ -154,7 +154,7 @@ public class DeptServiceImpl implements DeptService {
         for (DeptDto deptDTO : deptDtos) {
             Map<String,Object> map = new LinkedHashMap<>();
             map.put("部门名称", deptDTO.getName());
-            map.put("部门状态", deptDTO.getEnabled() ? "启用" : "停用");
+            map.put("部门状态", deptDTO.getEnabled() == 1 ? "启用" : "停用");
             map.put("创建日期", deptDTO.getCreateTime());
             list.add(map);
         }
@@ -177,7 +177,7 @@ public class DeptServiceImpl implements DeptService {
     public List<Long> getDeptChildren(Long deptId, List<Dept> deptList) {
         List<Long> list = new ArrayList<>();
         deptList.forEach(dept -> {
-                    if (dept!=null && dept.getEnabled()){
+                    if (dept!=null && (dept.getEnabled() == 1)){
                         List<Dept> depts = deptRepository.findByPid(dept.getId());
                         if(deptList.size() != 0){
                             list.addAll(getDeptChildren(dept.getId(), depts));

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/JobServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/JobServiceImpl.java
@@ -109,7 +109,7 @@ public class JobServiceImpl implements JobService {
         for (JobDto jobDTO : jobDtos) {
             Map<String,Object> map = new LinkedHashMap<>();
             map.put("岗位名称", jobDTO.getName());
-            map.put("岗位状态", jobDTO.getEnabled() ? "启用" : "停用");
+            map.put("岗位状态", jobDTO.getEnabled() == 1 ? "启用" : "停用");
             map.put("创建日期", jobDTO.getCreateTime());
             list.add(map);
         }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
@@ -120,7 +120,7 @@ public class UserServiceImpl implements UserService {
             redisUtils.del("user::username:" + user.getUsername());
         }
         // 如果用户被禁用，则清除用户登录信息
-        if(!resources.getEnabled()){
+        if(!(resources.getEnabled() == 1)){
             onlineUserService.kickOutForUsername(resources.getUsername());
         }
         user.setUsername(resources.getUsername());
@@ -218,7 +218,7 @@ public class UserServiceImpl implements UserService {
             map.put("部门", userDTO.getDept().getName());
             map.put("岗位", userDTO.getJobs().stream().map(JobSmallDto::getName).collect(Collectors.toList()));
             map.put("邮箱", userDTO.getEmail());
-            map.put("状态", userDTO.getEnabled() ? "启用" : "禁用");
+            map.put("状态", userDTO.getEnabled() == 1 ? "启用" : "禁用");
             map.put("手机号码", userDTO.getPhone());
             map.put("修改密码的时间", userDTO.getPwdResetTime());
             map.put("创建日期", userDTO.getCreateTime());


### PR DESCRIPTION
原始的varchar类型值在操作较多的字典详情数据时有诸多不便。
- 将sys_dict_detail数据表的value字段类型从varchar改为smallint
- 解决了用户管理、部门管理、岗位管理由于改动数据类型而引发的状态异常