### PR TITLE
fix bug: 修复算数型验证码生成浮点型结果，导致前端输入整形数据匹配错误

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
@@ -122,7 +122,7 @@ public class AuthorizationController {
         String uuid = properties.getCodeKey() + IdUtil.simpleUUID();
         //当验证码类型为 arithmetic时且长度 >= 2 时，captcha.text()的结果有几率为浮点型
         String captchaValue = captcha.text();
-        if (captcha.getCharType() - 1 == LoginCodeEnum.arithmetic.ordinal() & captchaValue.contains(".")) {
+        if (captcha.getCharType() - 1 == LoginCodeEnum.arithmetic.ordinal() && captchaValue.contains(".")) {
             captchaValue = captchaValue.split("\\.")[0];
         }
         // 保存

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
@@ -27,6 +27,7 @@ import me.zhengjie.annotation.rest.AnonymousGetMapping;
 import me.zhengjie.annotation.rest.AnonymousPostMapping;
 import me.zhengjie.config.RsaProperties;
 import me.zhengjie.exception.BadRequestException;
+import me.zhengjie.modules.security.config.bean.LoginCodeEnum;
 import me.zhengjie.modules.security.config.bean.LoginProperties;
 import me.zhengjie.modules.security.config.bean.SecurityProperties;
 import me.zhengjie.modules.security.security.TokenProvider;
@@ -119,8 +120,13 @@ public class AuthorizationController {
         // 获取运算的结果
         Captcha captcha = loginProperties.getCaptcha();
         String uuid = properties.getCodeKey() + IdUtil.simpleUUID();
+        //当验证码类型为 arithmetic时，运算结果为0时，captcha.text()的结果为0.0
+        String captchaValue = captcha.text();
+        if (captcha.getCharType() - 1 == LoginCodeEnum.arithmetic.ordinal() & captchaValue.equalsIgnoreCase("0.0")) {
+            captchaValue = "0";
+        }
         // 保存
-        redisUtils.set(uuid, captcha.text(), loginProperties.getLoginCode().getExpiration(), TimeUnit.MINUTES);
+        redisUtils.set(uuid, captchaValue, loginProperties.getLoginCode().getExpiration(), TimeUnit.MINUTES);
         // 验证码信息
         Map<String, Object> imgResult = new HashMap<String, Object>(2) {{
             put("img", captcha.toBase64());

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
@@ -120,10 +120,10 @@ public class AuthorizationController {
         // 获取运算的结果
         Captcha captcha = loginProperties.getCaptcha();
         String uuid = properties.getCodeKey() + IdUtil.simpleUUID();
-        //当验证码类型为 arithmetic时，运算结果为0时，captcha.text()的结果为0.0
+        //当验证码类型为 arithmetic时且长度 >= 2 时，captcha.text()的结果有几率为浮点型
         String captchaValue = captcha.text();
-        if (captcha.getCharType() - 1 == LoginCodeEnum.arithmetic.ordinal() & captchaValue.equalsIgnoreCase("0.0")) {
-            captchaValue = "0";
+        if (captcha.getCharType() - 1 == LoginCodeEnum.arithmetic.ordinal() & captchaValue.contains(".")) {
+            captchaValue = captchaValue.split("\\.")[0];
         }
         // 保存
         redisUtils.set(uuid, captchaValue, loginProperties.getLoginCode().getExpiration(), TimeUnit.MINUTES);


### PR DESCRIPTION
#463 当验证码类型为 arithmetic时，且验证码生成为0时，/auth/code/接口中的captcha.text()的结果为0.0，导致存入redis中的验证码值也为0.0，进而前端输入0和redis中的不匹配，提示验证码错误