### PR TITLE
修复链接失败会一直重连,并且连接成功之后也不缓存下来

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/mnt/util/SqlUtils.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/mnt/util/SqlUtils.java
@@ -20,13 +20,15 @@ import com.alibaba.druid.pool.DruidDataSource;
 import com.alibaba.druid.util.StringUtils;
 import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
+
 import javax.sql.DataSource;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author /
@@ -36,20 +38,6 @@ public class SqlUtils {
 
 	public static final String COLON = ":";
 
-	private static volatile Map<String, DruidDataSource> map = new HashMap<>();
-
-	private static String getKey(String jdbcUrl, String username, String password) {
-		StringBuilder sb = new StringBuilder();
-		if (!StringUtils.isEmpty(username)) {
-			sb.append(username);
-		}
-		if (!StringUtils.isEmpty(password)) {
-			sb.append(COLON).append(password);
-		}
-		sb.append(COLON).append(jdbcUrl.trim());
-
-		return SecureUtil.md5(sb.toString());
-	}
 
 	/**
 	 * 获取数据源
@@ -60,55 +48,44 @@ public class SqlUtils {
 	 * @return DataSource
 	 */
 	private static DataSource getDataSource(String jdbcUrl, String userName, String password) {
-		String key = getKey(jdbcUrl, userName, password);
-		if (!map.containsKey(key) || null == map.get(key)) {
-			DruidDataSource druidDataSource = new DruidDataSource();
-
-			String className;
-			try {
-				className = DriverManager.getDriver(jdbcUrl.trim()).getClass().getName();
-			} catch (SQLException e) {
-				throw new RuntimeException("Get class name error: =" + jdbcUrl);
-			}
-			if (StringUtils.isEmpty(className)) {
-				DataTypeEnum dataTypeEnum = DataTypeEnum.urlOf(jdbcUrl);
-				if (null == dataTypeEnum) {
-					throw new RuntimeException("Not supported data type: jdbcUrl=" + jdbcUrl);
-				}
-				druidDataSource.setDriverClassName(dataTypeEnum.getDriver());
-			} else {
-				druidDataSource.setDriverClassName(className);
-			}
-
-
-			druidDataSource.setUrl(jdbcUrl);
-			druidDataSource.setUsername(userName);
-			druidDataSource.setPassword(password);
-			// 配置获取连接等待超时的时间
-			druidDataSource.setMaxWait(3000);
-			// 配置初始化大小、最小、最大
-			druidDataSource.setInitialSize(1);
-			druidDataSource.setMinIdle(1);
-			druidDataSource.setMaxActive(1);
-
-			// 配置间隔多久才进行一次检测需要关闭的空闲连接，单位是毫秒
-			druidDataSource.setTimeBetweenEvictionRunsMillis(50000);
-			// 配置一旦重试多次失败后等待多久再继续重试连接，单位是毫秒
-			druidDataSource.setTimeBetweenConnectErrorMillis(18000);
-			// 配置一个连接在池中最小生存的时间，单位是毫秒
-			druidDataSource.setMinEvictableIdleTimeMillis(300000);
-			// 这个特性能解决 MySQL 服务器8小时关闭连接的问题
-			druidDataSource.setMaxEvictableIdleTimeMillis(25200000);
-
-			try {
-				druidDataSource.init();
-			} catch (SQLException e) {
-				log.error("Exception during pool initialization", e);
-				throw new RuntimeException(e.getMessage());
-			}
-			map.put(key, druidDataSource);
+		DruidDataSource druidDataSource = new DruidDataSource();
+		String className;
+		try {
+			className = DriverManager.getDriver(jdbcUrl.trim()).getClass().getName();
+		} catch (SQLException e) {
+			throw new RuntimeException("Get class name error: =" + jdbcUrl);
 		}
-		return map.get(key);
+		if (StringUtils.isEmpty(className)) {
+			DataTypeEnum dataTypeEnum = DataTypeEnum.urlOf(jdbcUrl);
+			if (null == dataTypeEnum) {
+				throw new RuntimeException("Not supported data type: jdbcUrl=" + jdbcUrl);
+			}
+			druidDataSource.setDriverClassName(dataTypeEnum.getDriver());
+		} else {
+			druidDataSource.setDriverClassName(className);
+		}
+
+
+		druidDataSource.setUrl(jdbcUrl);
+		druidDataSource.setUsername(userName);
+		druidDataSource.setPassword(password);
+		// 配置获取连接等待超时的时间
+		druidDataSource.setMaxWait(3000);
+		// 配置初始化大小、最小、最大
+		druidDataSource.setInitialSize(1);
+		druidDataSource.setMinIdle(1);
+		druidDataSource.setMaxActive(1);
+
+		// 如果链接出现异常则直接判定为失败而不是一直重试
+		druidDataSource.setBreakAfterAcquireFailure(true);
+		try {
+			druidDataSource.init();
+		} catch (SQLException e) {
+			log.error("Exception during pool initialization", e);
+			throw new RuntimeException(e.getMessage());
+		}
+
+		return druidDataSource;
 	}
 
 	private static Connection getConnection(String jdbcUrl, String userName, String password) {
@@ -187,14 +164,14 @@ public class SqlUtils {
 	 * @param sqlList /
 	 */
 	public static void batchExecute(Connection connection, List<String> sqlList) throws SQLException {
-			Statement st = connection.createStatement();
-			for (String sql : sqlList) {
-				if (sql.endsWith(";")) {
-					sql = sql.substring(0, sql.length() - 1);
-				}
-				st.addBatch(sql);
+		Statement st = connection.createStatement();
+		for (String sql : sqlList) {
+			if (sql.endsWith(";")) {
+				sql = sql.substring(0, sql.length() - 1);
 			}
-			st.executeBatch();
+			st.addBatch(sql);
+		}
+		st.executeBatch();
 	}
 
 	/**


### PR DESCRIPTION
修改了两个地方:

- druid 的链接参数,如果失败则不再重试
- 如果测试成功,不再缓存起来,因为测试完成之后会有释放的动作

修复了以下问题:
- 如果填写了一个不正确的链接,测试结果已经返回给前端,但是后端仍然在不断的重试,这是由于druid的配置导致的,同时 druid的重试的逻辑有太多的变量去控制看起来也是不合理的.
- 如果链接正确会缓存到本地,但是最终又释放掉了链接,目前看来没有用处
