### PR TITLE
 [代码修复](v2.6)：修复手机号可以重复的bug

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/repository/UserRepository.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/repository/UserRepository.java
@@ -45,6 +45,13 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
     User findByEmail(String email);
 
     /**
+     * 根据手机号查询
+     * @param phone 手机号
+     * @return /
+     */
+    User findByPhone(String phone);
+
+    /**
      * 修改密码
      * @param username 用户名
      * @param pass 密码

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
@@ -91,6 +91,9 @@ public class UserServiceImpl implements UserService {
         if (userRepository.findByEmail(resources.getEmail()) != null) {
             throw new EntityExistException(User.class, "email", resources.getEmail());
         }
+        if (userRepository.findByPhone(resources.getPhone()) != null) {
+            throw new EntityExistException(User.class, "phone", resources.getPhone());
+        }
         userRepository.save(resources);
     }
 
@@ -101,13 +104,15 @@ public class UserServiceImpl implements UserService {
         ValidationUtil.isNull(user.getId(), "User", "id", resources.getId());
         User user1 = userRepository.findByUsername(resources.getUsername());
         User user2 = userRepository.findByEmail(resources.getEmail());
-
+        User user3 = userRepository.findByPhone(resources.getPhone());
         if (user1 != null && !user.getId().equals(user1.getId())) {
             throw new EntityExistException(User.class, "username", resources.getUsername());
         }
-
         if (user2 != null && !user.getId().equals(user2.getId())) {
             throw new EntityExistException(User.class, "email", resources.getEmail());
+        }
+        if (user3 != null && !user.getId().equals(user3.getId())) {
+            throw new EntityExistException(User.class, "phone", resources.getPhone());
         }
         // 如果用户的角色改变
         if (!resources.getRoles().equals(user.getRoles())) {
@@ -141,6 +146,10 @@ public class UserServiceImpl implements UserService {
     @Transactional(rollbackFor = Exception.class)
     public void updateCenter(User resources) {
         User user = userRepository.findById(resources.getId()).orElseGet(User::new);
+        User user1 = userRepository.findByPhone(resources.getPhone());
+        if (user1 != null && !user.getId().equals(user1.getId())) {
+            throw new EntityExistException(User.class, "phone", resources.getPhone());
+        }
         user.setNickName(resources.getNickName());
         user.setPhone(resources.getPhone());
         user.setGender(resources.getGender());

--- a/sql/eladmin.sql
+++ b/sql/eladmin.sql
@@ -656,7 +656,7 @@ CREATE TABLE `sys_user` (
 -- ----------------------------
 BEGIN;
 INSERT INTO `sys_user` VALUES (1, 2, 'admin', '管理员', '男', '18888888888', '201507802@qq.com', 'avatar-20200806032259161.png', '/Users/jie/Documents/work/me/admin/eladmin/~/avatar/avatar-20200806032259161.png', '$2a$10$Egp1/gvFlt7zhlXVfEFw4OfWQCGPw0ClmMcc6FjTnvXNRVf9zdMRa', b'1', 1, NULL, 'admin', '2020-05-03 16:38:31', '2018-08-23 09:11:56', '2020-09-05 10:43:31');
-INSERT INTO `sys_user` VALUES (2, 2, 'test', '测试', '男', '18888888888', '231@qq.com', NULL, NULL, '$2a$10$4XcyudOYTSz6fue6KFNMHeUQnCX5jbBQypLEnGk1PmekXt5c95JcK', b'0', 1, 'admin', 'admin', NULL, '2020-05-05 11:15:49', '2020-09-05 10:43:38');
+INSERT INTO `sys_user` VALUES (2, 2, 'test', '测试', '男', '19999999999', '231@qq.com', NULL, NULL, '$2a$10$4XcyudOYTSz6fue6KFNMHeUQnCX5jbBQypLEnGk1PmekXt5c95JcK', b'0', 1, 'admin', 'admin', NULL, '2020-05-05 11:15:49', '2020-09-05 10:43:38');
 COMMIT;
 
 -- ----------------------------


### PR DESCRIPTION
我记得v2.5的时候sql里对**phone**字段加了唯一限制，v2.6好像去掉了，但是手机号在个人中心显示的仍为**不可重复**，所以此PR针对增加、更新、个人中心更新添加了手机号不能重复判断。
**如果目前数据库里有错误的数据，即手机号相同的用户，会导致userRepository.findByPhone报查询结果不唯一的错误，正常情况下不会有该异常**。