### PR TITLE
 [代码修复](v2.6)：修复禁用无角色用户时报错

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/RoleServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/RoleServiceImpl.java
@@ -154,6 +154,9 @@ public class RoleServiceImpl implements RoleService {
 
     @Override
     public Integer findByRoles(Set<Role> roles) {
+        if (roles.size() == 0) {
+            return Integer.MAX_VALUE;
+        }
         Set<RoleDto> roleDtos = new HashSet<>();
         for (Role role : roles) {
             roleDtos.add(findById(role.getId()));


### PR DESCRIPTION
未通过后台主动增加用户时，可以跳过分配角色，也就是说用户角色可能为空，这个时候在后台禁用该没有角色的用户时，由于要判断用户角色等级，会报
```java
ERROR m.z.e.handler.GlobalExceptionHandler - java.util.NoSuchElementException
        at java.util.ArrayList$Itr.next(ArrayList.java:854)
	at java.util.Collections.min(Collections.java:596)
        at me.zhengjie.modules.system.service.impl.RoleServiceImpl.findByRoles(RoleServiceImpl.java:164)
```
所以修改**根据角色查询角色级别**接口实现方法，如果传入角色集合为空，则返回**Integer.MAX_VALUE**，即最低等级。
（**不考虑修改人无角色的情况**）