### PR TITLE
[代码优化](v2.6)：去除deptService.getDeptChildren无用参数Long deptId

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/UserController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/UserController.java
@@ -79,8 +79,7 @@ public class UserController {
     public ResponseEntity<Object> query(UserQueryCriteria criteria, Pageable pageable){
         if (!ObjectUtils.isEmpty(criteria.getDeptId())) {
             criteria.getDeptIds().add(criteria.getDeptId());
-            criteria.getDeptIds().addAll(deptService.getDeptChildren(criteria.getDeptId(),
-                    deptService.findByPid(criteria.getDeptId())));
+            criteria.getDeptIds().addAll(deptService.getDeptChildren(deptService.findByPid(criteria.getDeptId())));
         }
         // 数据权限
         List<Long> dataScopes = dataService.getDeptIds(userService.findByName(SecurityUtils.getCurrentUsername()));

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DeptService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DeptService.java
@@ -111,11 +111,10 @@ public interface DeptService {
 
     /**
      * 获取
-     * @param deptId
      * @param deptList
      * @return
      */
-    List<Long> getDeptChildren(Long deptId, List<Dept> deptList);
+    List<Long> getDeptChildren(List<Dept> deptList);
 
     /**
      * 验证是否被角色或用户关联

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DataServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DataServiceImpl.java
@@ -83,7 +83,7 @@ public class DataServiceImpl implements DataService {
             deptIds.add(dept.getId());
             List<Dept> deptChildren = deptService.findByPid(dept.getId());
             if (deptChildren != null && deptChildren.size() != 0) {
-                deptIds.addAll(deptService.getDeptChildren(dept.getId(), deptChildren));
+                deptIds.addAll(deptService.getDeptChildren(deptChildren));
             }
         }
         return deptIds;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
@@ -172,13 +172,13 @@ public class DeptServiceImpl implements DeptService {
     }
 
     @Override
-    public List<Long> getDeptChildren(Long deptId, List<Dept> deptList) {
+    public List<Long> getDeptChildren(List<Dept> deptList) {
         List<Long> list = new ArrayList<>();
         deptList.forEach(dept -> {
-                    if (dept!=null && dept.getEnabled()){
+                    if (dept!=null && dept.getEnabled()) {
                         List<Dept> depts = deptRepository.findByPid(dept.getId());
-                        if(deptList.size() != 0){
-                            list.addAll(getDeptChildren(dept.getId(), depts));
+                        if (deptList.size() != 0) {
+                            list.addAll(getDeptChildren(depts));
                         }
                         list.add(dept.getId());
                     }


### PR DESCRIPTION
发现原 **deptService.getDeptChildren** 接口的实现方法里，并没有对参数 **deptId** 进行操作，原方法在dfs查询中已经将第一次传入部门的id加入list并返回，所以 **Long deptId** 这个参数并没有实际作用，故删去，并对其他调用该方法的代码做了相应调整。