### PR TITLE
[Fix] 磁盘使用率计算bug, 机器挂载多盘时只计算了最后一块盘

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/MonitorServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/MonitorServiceImpl.java
@@ -73,15 +73,18 @@ public class MonitorServiceImpl implements MonitorService {
         Map<String,Object> diskInfo = new LinkedHashMap<>();
         FileSystem fileSystem = os.getFileSystem();
         List<OSFileStore> fsArray = fileSystem.getFileStores();
-        for (OSFileStore fs : fsArray){
-            long available = fs.getUsableSpace();
-            long total = fs.getTotalSpace();
-            long used = total - available;
-            diskInfo.put("total", total > 0 ? FileUtil.getSize(total) : "?");
-            diskInfo.put("available", FileUtil.getSize(available));
-            diskInfo.put("used", FileUtil.getSize(used));
-            diskInfo.put("usageRate", df.format(used/(double)fs.getTotalSpace() * 100));
+        long available = 0L;
+        long total = 0L;
+        long used = 0L;
+        for (OSFileStore fs : fsArray) {
+            available += fs.getUsableSpace();
+            total += fs.getTotalSpace();
         }
+        used += total - available;
+        diskInfo.put("total", total > 0 ? FileUtil.getSize(total) : "?");
+        diskInfo.put("available", FileUtil.getSize(available));
+        diskInfo.put("used", FileUtil.getSize(used));
+        diskInfo.put("usageRate", df.format(used/(double)total * 100));
         return diskInfo;
     }
 


### PR DESCRIPTION
我调试时运行在一台虚机上，该虚机挂载多块磁盘（目前各大云厂商基本支持多云盘挂载），下图为我的虚机磁盘信息。
![image](https://user-images.githubusercontent.com/30440198/99899691-39473400-2ce6-11eb-9f0e-be924e7a6e16.png)

修复前：
![image](https://user-images.githubusercontent.com/30440198/99899773-e15cfd00-2ce6-11eb-9b10-7683baa09fe4.png)

修复后：
![image](https://user-images.githubusercontent.com/30440198/99899703-524fe500-2ce6-11eb-836d-795ed606c08c.png)
