### PR TITLE
[代码修复](v2.6)：修复清理dept缓存时 data::user: 未被清理

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/repository/UserRepository.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/repository/UserRepository.java
@@ -81,12 +81,12 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
 
     /**
      * 根据角色中的部门查询
-     * @param id /
+     * @param deptId /
      * @return /
      */
     @Query(value = "SELECT u.* FROM sys_user u, sys_users_roles r, sys_roles_depts d WHERE " +
-            "u.user_id = r.user_id AND r.role_id = d.role_id AND r.role_id = ?1 group by u.user_id", nativeQuery = true)
-    List<User> findByDeptRoleId(Long id);
+            "u.user_id = r.user_id AND r.role_id = d.role_id AND d.dept_id = ?1 group by u.user_id", nativeQuery = true)
+    List<User> findByRoleDeptId(Long deptId);
 
     /**
      * 根据菜单查询

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
@@ -273,7 +273,7 @@ public class DeptServiceImpl implements DeptService {
      * @param id /
      */
     public void delCaches(Long id){
-        List<User> users = userRepository.findByDeptRoleId(id);
+        List<User> users = userRepository.findByRoleDeptId(id);
         // 删除数据权限
         redisUtils.delByKeys(CacheKey.DATA_USER, users.stream().map(User::getId).collect(Collectors.toSet()));
         redisUtils.del(CacheKey.DEPT_ID + id);


### PR DESCRIPTION
- 原先在清理dept缓存时，在delcache中调用方法findByDeptRoleId，参数传的实际为部门dept_id，但是sql语句中关联查询最后是通过sys_users_roles的role_id与该dept_id参数相等做的条件，故修改为sys_roles_depts中的dept_id。
- 同时为了不被命名误导，将方法名findByDeptRoleId改为findByRoleDeptId。