### PR TITLE
Spring Boot版本升级2.2.10，解决in 查询传null时报错。调整Swagger中token设置方式

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DeptServiceImpl.java
@@ -58,7 +58,7 @@ public class DeptServiceImpl implements DeptService {
 
     @Override
     public List<DeptDto> queryAll(DeptQueryCriteria criteria, Boolean isQuery) throws Exception {
-        Sort sort = new Sort(Sort.Direction.ASC, "deptSort");
+        Sort sort = Sort.by(Sort.Direction.ASC, "deptSort");
         String dataScopeType = SecurityUtils.getDataScopeType();
         if (isQuery) {
             if(dataScopeType.equals(DataScopeEnum.ALL.getValue())){

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/MenuServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/MenuServiceImpl.java
@@ -61,7 +61,7 @@ public class MenuServiceImpl implements MenuService {
 
     @Override
     public List<MenuDto> queryAll(MenuQueryCriteria criteria, Boolean isQuery) throws Exception {
-        Sort sort = new Sort(Sort.Direction.ASC, "menuSort");
+        Sort sort = Sort.by(Sort.Direction.ASC, "menuSort");
         if(isQuery){
             criteria.setPidIsNull(true);
             List<Field> fields = QueryHelp.getAllFields(criteria.getClass(), new ArrayList<>());

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/RoleServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/RoleServiceImpl.java
@@ -66,7 +66,7 @@ public class RoleServiceImpl implements RoleService {
 
     @Override
     public List<RoleDto> queryAll() {
-        Sort sort = new Sort(Sort.Direction.ASC, "level");
+        Sort sort = Sort.by(Sort.Direction.ASC, "level");
         return roleMapper.toDto(roleRepository.findAll(sort));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.10.RELEASE</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
当in 查询传null时，2.2之前版本sql为 in ()，会报错。2.2版本sql为 in (null)。建议进行升级。升级后Sort的设置方式有变更，由new Sort()改为Sort.by()
关于Swagger中token的设置方式也做了调整，可以视情况合并。
最后感谢大佬的付出。