### PR TITLE
增强 RSAUtils 以解决 RSA 加密/解密长度限制

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/utils/RsaUtils.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/RsaUtils.java
@@ -2,6 +2,7 @@ package me.zhengjie.utils;
 
 import org.apache.commons.codec.binary.Base64;
 import javax.crypto.Cipher;
+import java.io.ByteArrayOutputStream;
 import java.security.*;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -80,7 +81,7 @@ public class RsaUtils {
         PublicKey publicKey = keyFactory.generatePublic(x509EncodedKeySpec);
         Cipher cipher = Cipher.getInstance("RSA");
         cipher.init(Cipher.DECRYPT_MODE, publicKey);
-        byte[] result = cipher.doFinal(Base64.decodeBase64(text));
+        byte[] result = doLongerCipherFinal(cipher, Base64.decodeBase64(text));
         return new String(result);
     }
 
@@ -98,7 +99,7 @@ public class RsaUtils {
         PrivateKey privateKey = keyFactory.generatePrivate(pkcs8EncodedKeySpec);
         Cipher cipher = Cipher.getInstance("RSA");
         cipher.init(Cipher.ENCRYPT_MODE, privateKey);
-        byte[] result = cipher.doFinal(text.getBytes());
+        byte[] result = doLongerCipherFinal(cipher, text.getBytes());
         return Base64.encodeBase64String(result);
     }
 
@@ -116,7 +117,7 @@ public class RsaUtils {
         PrivateKey privateKey = keyFactory.generatePrivate(pkcs8EncodedKeySpec5);
         Cipher cipher = Cipher.getInstance("RSA");
         cipher.init(Cipher.DECRYPT_MODE, privateKey);
-        byte[] result = cipher.doFinal(Base64.decodeBase64(text));
+        byte[] result = doLongerCipherFinal(cipher, Base64.decodeBase64(text));
         return new String(result);
     }
 
@@ -133,8 +134,21 @@ public class RsaUtils {
         PublicKey publicKey = keyFactory.generatePublic(x509EncodedKeySpec2);
         Cipher cipher = Cipher.getInstance("RSA");
         cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-        byte[] result = cipher.doFinal(text.getBytes());
+        byte[] result = doLongerCipherFinal(cipher, text.getBytes());
         return Base64.encodeBase64String(result);
+    }
+
+    private static byte[] doLongerCipherFinal(Cipher cipher, byte[] source) throws Exception {
+        int offset = 0;
+        int totalSize = source.length;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        while (totalSize - offset > 0) {
+            int size = Math.min(1024 / 8 - 11, totalSize - offset);
+            out.write(cipher.doFinal(source, offset, size));
+            offset += size;
+        }
+        out.close();
+        return out.toByteArray();
     }
 
     /**


### PR DESCRIPTION
RSA 单次加密/解密长度受证书长度限制，最大支持长度为: 证书长度 / 8 - 11

例:
   1024位RSA证书，单次最大加密/解密 1024 / 8 - 11 = 117 位
   4096位RSA证书，单次最大加密/解密 4096 / 8 - 11 = 501 位

详见 https://stackoverflow.com/a/5586652

内容超出长度限制后抛出异常:

javax.crypto.IllegalBlockSizeException: Data must not be longer than 117 bytes
   at java.base/com.sun.crypto.provider.RSACipher.doFinal(RSACipher.java:347)
   at java.base/com.sun.crypto.provider.RSACipher.engineDoFinal(RSACipher.java:392)
   at java.base/javax.crypto.Cipher.doFinal(Cipher.java:2205)
   at me.zhengjie.utils.RsaUtils.encryptByPrivateKey(RsaUtils.java:102)
