### PR TITLE
修复算术类型验证码在 Java 15+ 的兼容问题

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginProperties.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginProperties.java
@@ -80,7 +80,7 @@ public class LoginProperties {
             switch (loginCode.getCodeType()) {
                 case arithmetic:
                     // 算术类型 https://gitee.com/whvse/EasyCaptcha
-                    captcha = new ArithmeticCaptcha(loginCode.getWidth(), loginCode.getHeight());
+                    captcha = new FixedArithmeticCaptcha(loginCode.getWidth(), loginCode.getHeight());
                     // 几位数运算，默认是两位
                     captcha.setLen(loginCode.getLength());
                     break;
@@ -108,5 +108,28 @@ public class LoginProperties {
             captcha.setFont(new Font(loginCode.getFontName(), Font.PLAIN, loginCode.getFontSize()));
         }
         return captcha;
+    }
+
+    static class FixedArithmeticCaptcha extends ArithmeticCaptcha {
+        public FixedArithmeticCaptcha(int width, int height) {
+            super(width, height);
+        }
+
+        @Override
+        protected char[] alphas() {
+            // 生成随机数字和运算符
+            int n1 = num(1, 10), n2 = num(1, 10);
+            int opt = num(3);
+
+            // 计算结果
+            int res = new int[]{n1 + n2, n1 - n2, n1 * n2}[opt];
+            // 转换为字符运算符
+            char optChar = "+-x".charAt(opt);
+
+            this.setArithmeticString(String.format("%s%c%s=?", n1, optChar, n2));
+            this.chars = String.valueOf(res);
+
+            return chars.toCharArray();
+        }
     }
 }


### PR DESCRIPTION
EasyCaptcha 的算术类型验证码使用 Nashorn 引擎求值，而该引擎在 Java 11 中标记为废弃，Java 15 中已经被移除。

由于上游仓库已经无人维护，所以只能在代码中覆写了相关方法

参考:
[com.wf.captcha.base.ArithmeticCaptchaAbstract#alphas](https://github.com/whvcse/EasyCaptcha/blob/da3501451b963a96455d9f31d60cfbb510524e6f/src/main/java/com/wf/captcha/base/ArithmeticCaptchaAbstract.java#L40)
  https://openjdk.java.net/jeps/335
  https://openjdk.java.net/jeps/372