### PR TITLE
更新 JNA 版本，适配 Apple M1 芯片

### DIFF
--- a/eladmin-system/pom.xml
+++ b/eladmin-system/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <jjwt.version>0.11.1</jjwt.version>
         <!-- oshi监控需要指定jna版本, 问题详见 https://github.com/oshi/oshi/issues/1040 -->
-        <jna.version>5.6.0</jna.version>
+        <jna.version>5.8.0</jna.version>
     </properties>
 
     <dependencies>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>5.3.6</version>
+            <version>5.7.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
旧版本的 JNA 未提供 Darwin-aarch64 版本的原生 JNI 库导致服务监控不可用

自 JNA 5.7.0 开始对 m1 芯片提供支持
https://github.com/java-native-access/jna/commit/2be4198489d26400a40bda337ca2fccd6982a42c#diff-d6a038c176b5df3cfcf2b1512ef7a63f57c7a207176bbbc6b3acc05acf75733a

-------
**5.6.0**
<img width="963" alt="image" src="https://user-images.githubusercontent.com/16133088/116054209-072f6900-a6ae-11eb-9139-c0e0637df1e7.png">

-------
**5.7.0+**
<img width="399" alt="image" src="https://user-images.githubusercontent.com/16133088/116054253-10203a80-a6ae-11eb-8a0d-e82bb7b0847a.png">
