### PR TITLE
修复手动清除子任务id后导致运行定时任务报错

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/quartz/service/impl/QuartzJobServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/quartz/service/impl/QuartzJobServiceImpl.java
@@ -16,6 +16,7 @@
 package me.zhengjie.modules.quartz.service.impl;
 
 import cn.hutool.core.util.IdUtil;
+import cn.hutool.core.util.StrUtil;
 import lombok.RequiredArgsConstructor;
 import me.zhengjie.exception.BadRequestException;
 import me.zhengjie.modules.quartz.domain.QuartzJob;
@@ -133,6 +134,10 @@ public class QuartzJobServiceImpl implements QuartzJobService {
     @Transactional(rollbackFor = Exception.class)
     public void executionSubJob(String[] tasks) throws InterruptedException {
         for (String id : tasks) {
+            if (StrUtil.isBlank(id)) {
+                // 如果是手动清除子任务id，会出现id为空字符串的问题
+                continue;
+            }
             QuartzJob quartzJob = findById(Long.parseLong(id));
             // 执行任务
             String uuid = IdUtil.simpleUUID();


### PR DESCRIPTION
当定时任务原先由子任务id配置，手动移除id后，因为jpa不会自动将该字段设置为空，只会设置为空字符串，这将导致在后面再次运行时，id为空字符串，转为long类型会报错