### PR TITLE
[代码优化] assert 断言可能的问题, 以及 argList 调用方法优化, RedisConfig 的注释与代码不一致问题

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/aspect/LimitAspect.java
+++ b/eladmin-common/src/main/java/me/zhengjie/aspect/LimitAspect.java
@@ -68,7 +68,7 @@ public class LimitAspect {
             }
         }
 
-        ImmutableList<Object> keys = ImmutableList.of(StringUtils.join(limit.prefix(), "_", key, "_", request.getRequestURI().replaceAll("/","_")));
+        ImmutableList<Object> keys = ImmutableList.of(StringUtils.join(limit.prefix(), "_", key, "_", request.getRequestURI().replace("/","_")));
 
         String luaScript = buildLuaScript();
         RedisScript<Number> redisScript = new DefaultRedisScript<>(luaScript, Number.class);

--- a/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
+++ b/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
@@ -39,11 +39,13 @@ import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import reactor.util.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+
 
 /**
  * @author Zheng Jie

--- a/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
+++ b/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
@@ -20,7 +20,6 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.parser.ParserConfig;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 import lombok.extern.slf4j.Slf4j;
-import me.zhengjie.utils.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;

--- a/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
+++ b/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
@@ -65,7 +65,7 @@ public class RedisConfig extends CachingConfigurerSupport {
         FastJsonRedisSerializer<Object> fastJsonRedisSerializer = new FastJsonRedisSerializer<>(Object.class);
         RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig();
         configuration = configuration.serializeValuesWith(RedisSerializationContext.
-                SerializationPair.fromSerializer(fastJsonRedisSerializer)).entryTtl(Duration.ofHours(6));
+                SerializationPair.fromSerializer(fastJsonRedisSerializer)).entryTtl(Duration.ofHours(2));
         return configuration;
     }
 
@@ -97,7 +97,7 @@ public class RedisConfig extends CachingConfigurerSupport {
     @Override
     public KeyGenerator keyGenerator() {
         return (target, method, params) -> {
-            Map<String,Object> container = new HashMap<>(3);
+            Map<String,Object> container = new HashMap<>();
             Class<?> targetClassClass = target.getClass();
             // 类地址
             container.put("class",targetClassClass.toGenericString());
@@ -203,13 +203,14 @@ class StringRedisSerializer implements RedisSerializer<Object> {
         return (bytes == null ? null : new String(bytes, charset));
     }
 
-    @Override
-    public byte[] serialize(Object object) {
-        String string = JSON.toJSONString(object);
-        if (StringUtils.isBlank(string)) {
-            return null;
-        }
-        string = string.replace("\"", "");
-        return string.getBytes(charset);
-    }
+	@Override
+	public @Nullable byte[] serialize(Object object) {
+		String string = JSON.toJSONString(object);
+
+		if (org.apache.commons.lang3.StringUtils.isBlank(string)) {
+			return null;
+		}
+		string = string.replace("\"", "");
+		return string.getBytes(charset);
+	}
 }

--- a/eladmin-logging/src/main/java/me/zhengjie/service/impl/LogServiceImpl.java
+++ b/eladmin-logging/src/main/java/me/zhengjie/service/impl/LogServiceImpl.java
@@ -125,7 +125,7 @@ public class LogServiceImpl implements LogService {
                 argList.add(map);
             }
         }
-        if (argList.size() == 0) {
+        if (argList.isEmpty() == 0) {
             return "";
         }
         return argList.size() == 1 ? JSONUtil.toJsonStr(argList.get(0)) : JSONUtil.toJsonStr(argList);

--- a/eladmin-logging/src/main/java/me/zhengjie/service/impl/LogServiceImpl.java
+++ b/eladmin-logging/src/main/java/me/zhengjie/service/impl/LogServiceImpl.java
@@ -79,7 +79,9 @@ public class LogServiceImpl implements LogService {
     @Override
     @Transactional(rollbackFor = Exception.class)
     public void save(String username, String browser, String ip, ProceedingJoinPoint joinPoint, Log log) {
-
+        if (log == null) {
+            throw new IllegalArgumentException("Log 不能为 null!");
+        }
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         Method method = signature.getMethod();
         me.zhengjie.annotation.Log aopLog = method.getAnnotation(me.zhengjie.annotation.Log.class);
@@ -88,12 +90,9 @@ public class LogServiceImpl implements LogService {
         String methodName = joinPoint.getTarget().getClass().getName() + "." + signature.getName() + "()";
 
         // 描述
-        if (log != null) {
-            log.setDescription(aopLog.value());
-        }
-        assert log != null;
+        log.setDescription(aopLog.value());
+        
         log.setRequestIp(ip);
-
         log.setAddress(StringUtils.getCityInfo(log.getRequestIp()));
         log.setMethod(methodName);
         log.setUsername(username);


### PR DESCRIPTION
LogServiceImpl.java
1. 断言不适合用于参数验证，因为断言可以在JVM中的运行时被禁用，这意味着错误的操作设置将完全消除预期的检查。此外，失败的断言会抛出断言错误，而不是抛出某种类型的异常。因此 Assert 如果抛出异常, 则难以排查。使用 if 代替 断言, 并抛出 IllegalArgumentException 更可控
2. collection 接口实现类调用 isEmpty() 方法比 size() == 0 更可读

RedisConfig.java
1. 注释写的是 默认两小时, 但是代码写的是 6 小时, 所以应以哪一个为标准 ? 
2. 当没有出现碰撞时, 固定的 3个 kv 对, size 达到 3 个, 如果方法参数不为空, 则会触发 HashMap 扩容, 影响性能3 + params.length > (2^2 * 0.75 = 3)
3 仍然引用的是 apache 的方法, 为了去除歧义, 应使用全类名指定
如果方法返回值包含 null, 则加上 @nullable 注解, 代码更易读

LimitAspect.java
传给 replaceAll 的参数不是正则表达式, replaceAll 和 replace 效果是一样的, 且 replaceAll 由于会调用 ava.util.regex.Pattern.compile（）方法, 导致性能消耗更大, 故修改为 replace() 更好
