### PR TITLE
[代码优化] 添加支持配置的可回收用户缓存

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserCacheClean.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserCacheClean.java
@@ -16,6 +16,7 @@
 
 package me.zhengjie.modules.security.service;
 
+import lombok.AllArgsConstructor;
 import me.zhengjie.utils.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -25,7 +26,10 @@ import org.springframework.stereotype.Component;
  * @apiNote: 用于清理 用户登录信息缓存，为防止Spring循环依赖与安全考虑 ，单独构成工具类
  */
 @Component
+@AllArgsConstructor
 public class UserCacheClean {
+
+    private final UserCacheManager userCacheManager;
 
     /**
      * 清理特定用户缓存信息<br>
@@ -35,7 +39,7 @@ public class UserCacheClean {
      */
     public void cleanUserCache(String userName) {
         if (StringUtils.isNotEmpty(userName)) {
-            UserDetailsServiceImpl.USER_DTO_CACHE.remove(userName);
+            userCacheManager.remove(userName);
         }
     }
 
@@ -44,6 +48,6 @@ public class UserCacheClean {
      * ,如发生角色授权信息变化，可以简便的全部失效缓存
      */
     public void cleanAll() {
-        UserDetailsServiceImpl.USER_DTO_CACHE.clear();
+        userCacheManager.clear();
     }
 }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserCacheManager.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserCacheManager.java
@@ -47,8 +47,8 @@ public class UserCacheManager {
     public void expel() {
         long now = System.currentTimeMillis();
         if (cache.size() < minEvictableSize ||
-                now < nextMinEvictableTime &&
-                        !expelLock.compareAndSet(true, false)) {
+                now < nextMinEvictableTime ||
+                !expelLock.compareAndSet(true, false)) {
             return;
         }
         long oldestTime = now;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserCacheManager.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/service/UserCacheManager.java
@@ -1,0 +1,110 @@
+package me.zhengjie.modules.security.service;
+
+import lombok.extern.slf4j.Slf4j;
+import me.zhengjie.modules.security.service.dto.JwtUserDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 用户缓存
+ *
+ * @author TikiWong
+ * @date 2022/1/27 8:23
+ **/
+@Slf4j
+@Component
+public class UserCacheManager {
+
+    @Value("${user-cache.min-evictable-size}")
+    private int minEvictableSize;
+    @Value("${user-cache.min-evictable-interval}")
+    private long minEvictableInterval;
+    @Value("${user-cache.min-idle-time}")
+    private long minIdleTime;
+
+    private final Map<String, Node> cache = new ConcurrentHashMap<>();
+    private final AtomicBoolean expelLock = new AtomicBoolean(true);
+    private long nextMinEvictableTime = 0;
+
+    public Future<JwtUserDto> putIfAbsent(String username, Future<JwtUserDto> ft) {
+        Node tryNode = new Node(ft);
+        Node node = cache.putIfAbsent(username, tryNode);
+        expel();
+        return nodeToDate(node);
+    }
+
+    /**
+     * 缓存回收
+     * 为避免超过边界后回收热点数据设置了最小生存时间
+     * 回收时会保留在最小生存时间内的数据
+     **/
+    public void expel() {
+        long now = System.currentTimeMillis();
+        if (cache.size() < minEvictableSize ||
+                now < nextMinEvictableTime &&
+                        !expelLock.compareAndSet(true, false)) {
+            return;
+        }
+        long oldestTime = now;
+        int evictedCount = 0;
+        try {
+            Iterator<Map.Entry<String, Node>> iterator = cache.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, Node> entry = iterator.next();
+                long nodeTime = entry.getValue().getTime();
+                if (nodeTime + minIdleTime < now) {
+                    iterator.remove();
+                    evictedCount++;
+                }
+                oldestTime = Math.min(oldestTime, nodeTime);
+            }
+        } finally {
+            this.nextMinEvictableTime = Math.max(now + minEvictableInterval, oldestTime);
+            expelLock.set(true);
+            log.info("回收掉【{}】条用户缓存, 剩余缓存数为【{}】,下次可回收时间为【{}】秒后",
+                    evictedCount,
+                    cache.size(),
+                    (this.nextMinEvictableTime - now) / 1000);
+        }
+    }
+
+    public Future<JwtUserDto> get(String username) {
+        return nodeToDate(cache.get(username));
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+
+    public void remove(String username) {
+        cache.remove(username);
+    }
+
+    private Future<JwtUserDto> nodeToDate(Node node) {
+        return node == null ? null : node.getData();
+    }
+
+    private static class Node {
+        private final Future<JwtUserDto> data;
+        private final long time;
+
+        public Node(Future<JwtUserDto> data) {
+            this.data = data;
+            this.time = System.currentTimeMillis();
+        }
+
+        public Future<JwtUserDto> getData() {
+            return data;
+        }
+
+        public long getTime() {
+            return time;
+        }
+    }
+}

--- a/eladmin-system/src/main/resources/config/application.yml
+++ b/eladmin-system/src/main/resources/config/application.yml
@@ -54,3 +54,12 @@ code:
 #密码加密传输，前端公钥加密，后端私钥解密
 rsa:
   private_key: MIIBUwIBADANBgkqhkiG9w0BAQEFAASCAT0wggE5AgEAAkEA0vfvyTdGJkdbHkB8mp0f3FE0GYP3AYPaJF7jUd1M0XxFSE2ceK3k2kw20YvQ09NJKk+OMjWQl9WitG9pB6tSCQIDAQABAkA2SimBrWC2/wvauBuYqjCFwLvYiRYqZKThUS3MZlebXJiLB+Ue/gUifAAKIg1avttUZsHBHrop4qfJCwAI0+YRAiEA+W3NK/RaXtnRqmoUUkb59zsZUBLpvZgQPfj1MhyHDz0CIQDYhsAhPJ3mgS64NbUZmGWuuNKp5coY2GIj/zYDMJp6vQIgUueLFXv/eZ1ekgz2Oi67MNCk5jeTF2BurZqNLR3MSmUCIFT3Q6uHMtsB9Eha4u7hS31tj1UWE+D+ADzp59MGnoftAiBeHT7gDMuqeJHPL4b+kC+gzV4FGTfhR9q3tTbklZkD2A==
+
+# 内存用户缓存配置
+user-cache:
+  # 最小回收数(当缓存数量达到此值时进行回收)
+  min-evictable-size: 512
+  # 最小回收间隔
+  min-evictable-interval: 1800000
+  # 最小存活时间 (ms)
+  min-idle-time: 3600000

--- a/eladmin-system/src/test/java/me/zhengjie/LoginCacheTest.java
+++ b/eladmin-system/src/test/java/me/zhengjie/LoginCacheTest.java
@@ -41,4 +41,24 @@ public class LoginCacheTest {
         System.out.print("使用缓存：" + (end1 - start1) + "毫秒\n 不使用缓存：" + (end2 - start2) + "毫秒");
     }
 
+    @Test
+    public void testCacheManager() throws InterruptedException {
+        int size = 1000;
+        CountDownLatch latch = new CountDownLatch(size);
+        for (int i = 0; i < size; i++) {
+            int mod = i % 10;
+            executor.submit(() -> {
+                try {
+                    Thread.sleep(mod * 2 + (int) (Math.random() * 10000));
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                userDetailsService.loadUserByUsername("admin" + mod);
+                latch.countDown();
+                System.out.println("剩余未完成数量" + latch.getCount());
+            });
+        }
+        latch.await();
+    }
+
 }


### PR DESCRIPTION
添加了UserCacheManager类，封装了UserDetailsServiceImpl中的用户缓存，并添加了回收功能
支持的参数如下
```
user-cache:
  min-evictable-size #最小回收数(当缓存数量达到此值时进行回收)
  min-evictable-interval: #最小回收间隔
  min-idle-time: 最小存活时间 (ms)
```
缓存的触发在putIfAbsent上，当进行putIfAbsent操作时，如 达到最小回收数量且两次回收间隔大于最小回收间隔时会执行回收操作，回收过程中会清除掉存活时常大于最小存活时间的用户信息。