### PR TITLE
[代码优化]枚举值调整为统一大写；枚举类的find方法优化

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/utils/enums/CodeBiEnum.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/enums/CodeBiEnum.java
@@ -40,7 +40,7 @@ public enum CodeBiEnum {
 
     public static CodeBiEnum find(Integer code) {
         for (CodeBiEnum value : CodeBiEnum.values()) {
-            if (code.equals(value.getCode())) {
+            if (value.getCode().equals(code)) {
                 return value;
             }
         }

--- a/eladmin-common/src/main/java/me/zhengjie/utils/enums/DataScopeEnum.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/enums/DataScopeEnum.java
@@ -43,7 +43,7 @@ public enum DataScopeEnum {
 
     public static DataScopeEnum find(String val) {
         for (DataScopeEnum dataScopeEnum : DataScopeEnum.values()) {
-            if (val.equals(dataScopeEnum.getValue())) {
+            if (dataScopeEnum.getValue().equals(val)) {
                 return dataScopeEnum;
             }
         }

--- a/eladmin-common/src/main/java/me/zhengjie/utils/enums/RequestMethodEnum.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/enums/RequestMethodEnum.java
@@ -65,7 +65,7 @@ public enum RequestMethodEnum {
 
     public static RequestMethodEnum find(String type) {
         for (RequestMethodEnum value : RequestMethodEnum.values()) {
-            if (type.equals(value.getType())) {
+            if (value.getType().equals(type)) {
                 return value;
             }
         }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginCodeEnum.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginCodeEnum.java
@@ -26,18 +26,18 @@ public enum LoginCodeEnum {
     /**
      * 算数
      */
-    arithmetic,
+    ARITHMETIC,
     /**
      * 中文
      */
-    chinese,
+    CHINESE,
     /**
      * 中文闪图
      */
-    chinese_gif,
+    CHINESE_GIF,
     /**
      * 闪图
      */
-    gif,
-    spec
+    GIF,
+    SPEC
 }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginProperties.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginProperties.java
@@ -62,7 +62,7 @@ public class LoginProperties {
         if (Objects.isNull(loginCode)) {
             loginCode = new LoginCode();
             if (Objects.isNull(loginCode.getCodeType())) {
-                loginCode.setCodeType(LoginCodeEnum.arithmetic);
+                loginCode.setCodeType(LoginCodeEnum.ARITHMETIC);
             }
         }
         return switchCaptcha(loginCode);
@@ -78,25 +78,25 @@ public class LoginProperties {
         Captcha captcha;
         synchronized (this) {
             switch (loginCode.getCodeType()) {
-                case arithmetic:
+                case ARITHMETIC:
                     // 算术类型 https://gitee.com/whvse/EasyCaptcha
                     captcha = new FixedArithmeticCaptcha(loginCode.getWidth(), loginCode.getHeight());
                     // 几位数运算，默认是两位
                     captcha.setLen(loginCode.getLength());
                     break;
-                case chinese:
+                case CHINESE:
                     captcha = new ChineseCaptcha(loginCode.getWidth(), loginCode.getHeight());
                     captcha.setLen(loginCode.getLength());
                     break;
-                case chinese_gif:
+                case CHINESE_GIF:
                     captcha = new ChineseGifCaptcha(loginCode.getWidth(), loginCode.getHeight());
                     captcha.setLen(loginCode.getLength());
                     break;
-                case gif:
+                case GIF:
                     captcha = new GifCaptcha(loginCode.getWidth(), loginCode.getHeight());
                     captcha.setLen(loginCode.getLength());
                     break;
-                case spec:
+                case SPEC:
                     captcha = new SpecCaptcha(loginCode.getWidth(), loginCode.getHeight());
                     captcha.setLen(loginCode.getLength());
                     break;

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/rest/AuthorizationController.java
@@ -123,7 +123,7 @@ public class AuthorizationController {
         String uuid = properties.getCodeKey() + IdUtil.simpleUUID();
         //当验证码类型为 arithmetic时且长度 >= 2 时，captcha.text()的结果有几率为浮点型
         String captchaValue = captcha.text();
-        if (captcha.getCharType() - 1 == LoginCodeEnum.arithmetic.ordinal() && captchaValue.contains(".")) {
+        if (captcha.getCharType() - 1 == LoginCodeEnum.ARITHMETIC.ordinal() && captchaValue.contains(".")) {
             captchaValue = captchaValue.split("\\.")[0];
         }
         // 保存


### PR DESCRIPTION
1、枚举值字段定义统一修改为大写；
2、几个枚举类的find方法，交换equals方法，避免可能出现的NPE。