### PR TITLE
fix weird prefixes keys when use RedisUtils.scan

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/utils/RedisUtils.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/RedisUtils.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.*;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -41,6 +42,9 @@ public class RedisUtils {
 
     public RedisUtils(RedisTemplate<Object, Object> redisTemplate) {
         this.redisTemplate = redisTemplate;
+        this.redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        this.redisTemplate.setKeySerializer(new StringRedisSerializer());
+        this.redisTemplate.setStringSerializer(new StringRedisSerializer());
     }
 
     /**


### PR DESCRIPTION
fix weird prefixes when use RedisUtils.scan method (spring-boot-starter-data-redis 2.6.6)

ref:
https://stackoverflow.com/questions/55967558/spring-data-redis-hash-keys-with-weird-prefixes-and-hscan-not-returning-resul
