### PR TITLE
修改HashMap初始化容量，减少不必要的扩容，提高性能

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
+++ b/eladmin-common/src/main/java/me/zhengjie/config/RedisConfig.java
@@ -106,7 +106,7 @@ public class RedisConfig extends CachingConfigurerSupport {
     @Override
     public KeyGenerator keyGenerator() {
         return (target, method, params) -> {
-            Map<String,Object> container = new HashMap<>(4);
+            Map<String,Object> container = new HashMap<>(8);
             Class<?> targetClassClass = target.getClass();
             // 类地址
             container.put("class",targetClassClass.toGenericString());

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginProperties.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/config/bean/LoginProperties.java
@@ -68,33 +68,31 @@ public class LoginProperties {
      */
     private Captcha switchCaptcha(LoginCode loginCode) {
         Captcha captcha;
-        synchronized (this) {
-            switch (loginCode.getCodeType()) {
-                case ARITHMETIC:
-                    // 算术类型 https://gitee.com/whvse/EasyCaptcha
-                    captcha = new FixedArithmeticCaptcha(loginCode.getWidth(), loginCode.getHeight());
-                    // 几位数运算，默认是两位
-                    captcha.setLen(loginCode.getLength());
-                    break;
-                case CHINESE:
-                    captcha = new ChineseCaptcha(loginCode.getWidth(), loginCode.getHeight());
-                    captcha.setLen(loginCode.getLength());
-                    break;
-                case CHINESE_GIF:
-                    captcha = new ChineseGifCaptcha(loginCode.getWidth(), loginCode.getHeight());
-                    captcha.setLen(loginCode.getLength());
-                    break;
-                case GIF:
-                    captcha = new GifCaptcha(loginCode.getWidth(), loginCode.getHeight());
-                    captcha.setLen(loginCode.getLength());
-                    break;
-                case SPEC:
-                    captcha = new SpecCaptcha(loginCode.getWidth(), loginCode.getHeight());
-                    captcha.setLen(loginCode.getLength());
-                    break;
-                default:
-                    throw new BadConfigurationException("验证码配置信息错误！正确配置查看 LoginCodeEnum ");
-            }
+        switch (loginCode.getCodeType()) {
+            case ARITHMETIC:
+                // 算术类型 https://gitee.com/whvse/EasyCaptcha
+                captcha = new FixedArithmeticCaptcha(loginCode.getWidth(), loginCode.getHeight());
+                // 几位数运算，默认是两位
+                captcha.setLen(loginCode.getLength());
+                break;
+            case CHINESE:
+                captcha = new ChineseCaptcha(loginCode.getWidth(), loginCode.getHeight());
+                captcha.setLen(loginCode.getLength());
+                break;
+            case CHINESE_GIF:
+                captcha = new ChineseGifCaptcha(loginCode.getWidth(), loginCode.getHeight());
+                captcha.setLen(loginCode.getLength());
+                break;
+            case GIF:
+                captcha = new GifCaptcha(loginCode.getWidth(), loginCode.getHeight());
+                captcha.setLen(loginCode.getLength());
+                break;
+            case SPEC:
+                captcha = new SpecCaptcha(loginCode.getWidth(), loginCode.getHeight());
+                captcha.setLen(loginCode.getLength());
+                break;
+            default:
+                throw new BadConfigurationException("验证码配置信息错误！正确配置查看 LoginCodeEnum ");
         }
         if(StringUtils.isNotBlank(loginCode.getFontName())){
             captcha.setFont(new Font(loginCode.getFontName(), Font.PLAIN, loginCode.getFontSize()));


### PR DESCRIPTION
自定义缓存key生成策略时，目前HashMap容量设置为4，按照JDK, 临界点在 4 * 0.75 =3时会触发扩容，也就是map中entry超过3时会自动扩容。
而方法中类地址，方法名称，包名称已经有3个了，只要“参数列表”不为空，必然会进行扩容，这样性能会受到影响，可以将初始化容量设为8或16，减少不必要的因为“参数列表”不为空而触发的扩容，提高性能。