### PR TITLE
优化tomcat配置relaxedQueryChars方式,采用TomcatConnectorCustomizer来实现

### DIFF
--- a/eladmin-system/src/main/java/me/zhengjie/AppRun.java
+++ b/eladmin-system/src/main/java/me/zhengjie/AppRun.java
@@ -56,13 +56,6 @@ public class AppRun {
         return new SpringContextHolder();
     }
 
-    @Bean
-    public ServletWebServerFactory webServerFactory() {
-        TomcatServletWebServerFactory fa = new TomcatServletWebServerFactory();
-        fa.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "[]{}"));
-        return fa;
-    }
-
     /**
      * 访问首页提示
      *

--- a/eladmin-system/src/main/java/me/zhengjie/config/RelaxedQueryCharsConnectorCustomizer
+++ b/eladmin-system/src/main/java/me/zhengjie/config/RelaxedQueryCharsConnectorCustomizer
@@ -1,0 +1,7 @@
+    @Configuration(proxyBeanMethods = false)
+    public class RelaxedQueryCharsConnectorCustomizer implements TomcatConnectorCustomizer {
+        @Override
+        public void customize(Connector connector) {
+            connector.setProperty("relaxedQueryChars", "[]{}");
+        }
+    }

--- a/eladmin-system/src/main/java/me/zhengjie/config/RelaxedQueryCharsConnectorCustomizer
+++ b/eladmin-system/src/main/java/me/zhengjie/config/RelaxedQueryCharsConnectorCustomizer
@@ -1,7 +1,16 @@
-    @Configuration(proxyBeanMethods = false)
-    public class RelaxedQueryCharsConnectorCustomizer implements TomcatConnectorCustomizer {
-        @Override
-        public void customize(Connector connector) {
-            connector.setProperty("relaxedQueryChars", "[]{}");
-        }
+package me.zhengjie.config;
+
+import org.apache.catalina.connector.Connector;
+import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author bearBoy80
+ */
+@Configuration(proxyBeanMethods = false)
+public class RelaxedQueryCharsConnectorCustomizer implements TomcatConnectorCustomizer {
+    @Override
+    public void customize(Connector connector) {
+        connector.setProperty("relaxedQueryChars", "[]{}");
     }
+}


### PR DESCRIPTION
之前实现通过
 ``` java @Bean
    public ServletWebServerFactory webServerFactory() {
        TomcatServletWebServerFactory fa = new TomcatServletWebServerFactory();
        fa.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "[]{}"));
        return fa;
    }
```
实现后，我们无法实现TomcatConnectorCustomizer来配置tomcat的参数，同时导致springboot默认提供一些扩展无法使用，比如TomcatContextCustomizer、TomcatProtocolHandlerCustomizer。
SpringBoot 自动化装配TomcatServletWebServerFactory代码类org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryConfiguration.EmbeddedTomcat如下:
```java 
        @Bean
        TomcatServletWebServerFactory tomcatServletWebServerFactory(ObjectProvider<TomcatConnectorCustomizer> connectorCustomizers, ObjectProvider<TomcatContextCustomizer> contextCustomizers, ObjectProvider<TomcatProtocolHandlerCustomizer<?>> protocolHandlerCustomizers) {
            TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
            factory.getTomcatConnectorCustomizers().addAll((Collection)connectorCustomizers.orderedStream().collect(Collectors.toList()));
            factory.getTomcatContextCustomizers().addAll((Collection)contextCustomizers.orderedStream().collect(Collectors.toList()));
            factory.getTomcatProtocolHandlerCustomizers().addAll((Collection)protocolHandlerCustomizers.orderedStream().collect(Collectors.toList()));
            return factory;
        }
```
其实tomcat配置relaxedQueryChars，还可以通过实现WebServerFactoryCustomizer,并实现Ordered接口
