### PR TITLE
feat: 增加分页实体 APage，使 Swagger 可显示接口的响应示例

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/utils/APage.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/APage.java
@@ -1,0 +1,17 @@
+package me.zhengjie.utils;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class APage<T> {
+
+    private final List<T> content;
+
+    private final long totalElements;
+
+}

--- a/eladmin-common/src/main/java/me/zhengjie/utils/PageResult.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/PageResult.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-public class APage<T> {
+public class PageResult<T> {
 
     private final List<T> content;
 

--- a/eladmin-common/src/main/java/me/zhengjie/utils/PageUtil.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/PageUtil.java
@@ -43,15 +43,15 @@ public class PageUtil extends cn.hutool.core.util.PageUtil {
     /**
      * Page 数据处理，预防redis反序列化报错
      */
-    public static <T> APage<T> toPage(Page<T> page) {
-        return new APage<>(page.getContent(), page.getTotalElements());
+    public static <T> PageResult<T> toPage(Page<T> page) {
+        return new PageResult<>(page.getContent(), page.getTotalElements());
     }
 
     /**
      * 自定义分页
      */
-    public static <T> APage<T> toPage(List<T> list, long totalElements) {
-        return new APage<>(list, totalElements);
+    public static <T> PageResult<T> toPage(List<T> list, long totalElements) {
+        return new PageResult<>(list, totalElements);
     }
 
 }

--- a/eladmin-common/src/main/java/me/zhengjie/utils/PageUtil.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/PageUtil.java
@@ -28,11 +28,11 @@ public class PageUtil extends cn.hutool.core.util.PageUtil {
     /**
      * List 分页
      */
-    public static List toPage(int page, int size , List list) {
+    public static <T> List<T> paging(int page, int size , List<T> list) {
         int fromIndex = page * size;
         int toIndex = page * size + size;
         if(fromIndex > list.size()){
-            return new ArrayList();
+            return Collections.emptyList();
         } else if(toIndex >= list.size()) {
             return list.subList(fromIndex,list.size());
         } else {
@@ -43,21 +43,15 @@ public class PageUtil extends cn.hutool.core.util.PageUtil {
     /**
      * Page 数据处理，预防redis反序列化报错
      */
-    public static Map<String,Object> toPage(Page page) {
-        Map<String,Object> map = new LinkedHashMap<>(2);
-        map.put("content",page.getContent());
-        map.put("totalElements",page.getTotalElements());
-        return map;
+    public static <T> APage<T> toPage(Page<T> page) {
+        return new APage<>(page.getContent(), page.getTotalElements());
     }
 
     /**
      * 自定义分页
      */
-    public static Map<String,Object> toPage(Object object, Object totalElements) {
-        Map<String,Object> map = new LinkedHashMap<>(2);
-        map.put("content",object);
-        map.put("totalElements",totalElements);
-        return map;
+    public static <T> APage<T> toPage(List<T> list, long totalElements) {
+        return new APage<>(list, totalElements);
     }
 
 }

--- a/eladmin-generator/src/main/java/me/zhengjie/service/impl/GeneratorServiceImpl.java
+++ b/eladmin-generator/src/main/java/me/zhengjie/service/impl/GeneratorServiceImpl.java
@@ -90,7 +90,7 @@ public class GeneratorServiceImpl implements GeneratorService {
                 "where table_schema = (select database()) and table_name like :table";
         Query queryCount = em.createNativeQuery(countSql);
         queryCount.setParameter("table", StringUtils.isNotBlank(name) ? ("%" + name + "%") : "%%");
-        Object totalElements = queryCount.getSingleResult();
+        long totalElements = (long) queryCount.getSingleResult();
         return PageUtil.toPage(tableInfos, totalElements);
     }
 

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/service/OnlineUserService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/service/OnlineUserService.java
@@ -16,6 +16,7 @@
 package me.zhengjie.modules.security.service;
 
 import lombok.extern.slf4j.Slf4j;
+import me.zhengjie.utils.APage;
 import me.zhengjie.modules.security.config.bean.SecurityProperties;
 import me.zhengjie.modules.security.service.dto.JwtUserDto;
 import me.zhengjie.modules.security.service.dto.OnlineUserDto;
@@ -70,10 +71,10 @@ public class OnlineUserService {
      * @param pageable /
      * @return /
      */
-    public Map<String,Object> getAll(String filter, Pageable pageable){
+    public APage<OnlineUserDto> getAll(String filter, Pageable pageable){
         List<OnlineUserDto> onlineUserDtos = getAll(filter);
         return PageUtil.toPage(
-                PageUtil.toPage(pageable.getPageNumber(),pageable.getPageSize(), onlineUserDtos),
+                PageUtil.paging(pageable.getPageNumber(),pageable.getPageSize(), onlineUserDtos),
                 onlineUserDtos.size()
         );
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/security/service/OnlineUserService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/security/service/OnlineUserService.java
@@ -16,7 +16,7 @@
 package me.zhengjie.modules.security.service;
 
 import lombok.extern.slf4j.Slf4j;
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.modules.security.config.bean.SecurityProperties;
 import me.zhengjie.modules.security.service.dto.JwtUserDto;
 import me.zhengjie.modules.security.service.dto.OnlineUserDto;
@@ -71,7 +71,7 @@ public class OnlineUserService {
      * @param pageable /
      * @return /
      */
-    public APage<OnlineUserDto> getAll(String filter, Pageable pageable){
+    public PageResult<OnlineUserDto> getAll(String filter, Pageable pageable){
         List<OnlineUserDto> onlineUserDtos = getAll(filter);
         return PageUtil.toPage(
                 PageUtil.paging(pageable.getPageNumber(),pageable.getPageSize(), onlineUserDtos),

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/UserController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/UserController.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import me.zhengjie.annotation.Log;
+import me.zhengjie.utils.APage;
 import me.zhengjie.config.RsaProperties;
 import me.zhengjie.modules.system.domain.Dept;
 import me.zhengjie.modules.system.service.DataService;
@@ -77,7 +78,7 @@ public class UserController {
     @ApiOperation("查询用户")
     @GetMapping
     @PreAuthorize("@el.check('user:list')")
-    public ResponseEntity<Object> queryUser(UserQueryCriteria criteria, Pageable pageable){
+    public ResponseEntity<APage<UserDto>> queryUser(UserQueryCriteria criteria, Pageable pageable){
         if (!ObjectUtils.isEmpty(criteria.getDeptId())) {
             criteria.getDeptIds().add(criteria.getDeptId());
             // 先查找是否存在子节点

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/UserController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/rest/UserController.java
@@ -20,7 +20,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import me.zhengjie.annotation.Log;
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.config.RsaProperties;
 import me.zhengjie.modules.system.domain.Dept;
 import me.zhengjie.modules.system.service.DataService;
@@ -78,7 +78,7 @@ public class UserController {
     @ApiOperation("查询用户")
     @GetMapping
     @PreAuthorize("@el.check('user:list')")
-    public ResponseEntity<APage<UserDto>> queryUser(UserQueryCriteria criteria, Pageable pageable){
+    public ResponseEntity<PageResult<UserDto>> queryUser(UserQueryCriteria criteria, Pageable pageable){
         if (!ObjectUtils.isEmpty(criteria.getDeptId())) {
             criteria.getDeptIds().add(criteria.getDeptId());
             // 先查找是否存在子节点

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictDetailService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictDetailService.java
@@ -15,12 +15,12 @@
  */
 package me.zhengjie.modules.system.service;
 
+import me.zhengjie.utils.APage;
 import me.zhengjie.modules.system.domain.DictDetail;
 import me.zhengjie.modules.system.service.dto.DictDetailDto;
 import me.zhengjie.modules.system.service.dto.DictDetailQueryCriteria;
 import org.springframework.data.domain.Pageable;
 import java.util.List;
-import java.util.Map;
 
 /**
 * @author Zheng Jie
@@ -52,7 +52,7 @@ public interface DictDetailService {
      * @param pageable 分页参数
      * @return /
      */
-    Map<String,Object> queryAll(DictDetailQueryCriteria criteria, Pageable pageable);
+    APage<DictDetailDto> queryAll(DictDetailQueryCriteria criteria, Pageable pageable);
 
     /**
      * 根据字典名称获取字典详情

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictDetailService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictDetailService.java
@@ -15,7 +15,7 @@
  */
 package me.zhengjie.modules.system.service;
 
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.modules.system.domain.DictDetail;
 import me.zhengjie.modules.system.service.dto.DictDetailDto;
 import me.zhengjie.modules.system.service.dto.DictDetailQueryCriteria;
@@ -52,7 +52,7 @@ public interface DictDetailService {
      * @param pageable 分页参数
      * @return /
      */
-    APage<DictDetailDto> queryAll(DictDetailQueryCriteria criteria, Pageable pageable);
+    PageResult<DictDetailDto> queryAll(DictDetailQueryCriteria criteria, Pageable pageable);
 
     /**
      * 根据字典名称获取字典详情

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictService.java
@@ -15,6 +15,7 @@
  */
 package me.zhengjie.modules.system.service;
 
+import me.zhengjie.utils.APage;
 import me.zhengjie.modules.system.domain.Dict;
 import me.zhengjie.modules.system.service.dto.DictDto;
 import me.zhengjie.modules.system.service.dto.DictQueryCriteria;
@@ -22,7 +23,6 @@ import org.springframework.data.domain.Pageable;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -37,7 +37,7 @@ public interface DictService {
      * @param pageable 分页参数
      * @return /
      */
-    Map<String,Object> queryAll(DictQueryCriteria criteria, Pageable pageable);
+    APage<DictDto> queryAll(DictQueryCriteria criteria, Pageable pageable);
 
     /**
      * 查询全部数据

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/DictService.java
@@ -15,7 +15,7 @@
  */
 package me.zhengjie.modules.system.service;
 
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.modules.system.domain.Dict;
 import me.zhengjie.modules.system.service.dto.DictDto;
 import me.zhengjie.modules.system.service.dto.DictQueryCriteria;
@@ -37,7 +37,7 @@ public interface DictService {
      * @param pageable 分页参数
      * @return /
      */
-    APage<DictDto> queryAll(DictQueryCriteria criteria, Pageable pageable);
+    PageResult<DictDto> queryAll(DictQueryCriteria criteria, Pageable pageable);
 
     /**
      * 查询全部数据

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/JobService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/JobService.java
@@ -15,6 +15,7 @@
  */
 package me.zhengjie.modules.system.service;
 
+import me.zhengjie.utils.APage;
 import me.zhengjie.modules.system.domain.Job;
 import me.zhengjie.modules.system.service.dto.JobDto;
 import me.zhengjie.modules.system.service.dto.JobQueryCriteria;
@@ -22,7 +23,6 @@ import org.springframework.data.domain.Pageable;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -63,7 +63,7 @@ public interface JobService {
      * @param pageable 分页参数
      * @return /
      */
-    Map<String,Object> queryAll(JobQueryCriteria criteria, Pageable pageable);
+    APage<JobDto> queryAll(JobQueryCriteria criteria, Pageable pageable);
 
     /**
      * 查询全部数据

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/JobService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/JobService.java
@@ -15,7 +15,7 @@
  */
 package me.zhengjie.modules.system.service;
 
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.modules.system.domain.Job;
 import me.zhengjie.modules.system.service.dto.JobDto;
 import me.zhengjie.modules.system.service.dto.JobQueryCriteria;
@@ -63,7 +63,7 @@ public interface JobService {
      * @param pageable 分页参数
      * @return /
      */
-    APage<JobDto> queryAll(JobQueryCriteria criteria, Pageable pageable);
+    PageResult<JobDto> queryAll(JobQueryCriteria criteria, Pageable pageable);
 
     /**
      * 查询全部数据

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/UserService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/UserService.java
@@ -15,7 +15,7 @@
  */
 package me.zhengjie.modules.system.service;
 
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.modules.system.domain.User;
 import me.zhengjie.modules.system.service.dto.UserDto;
 import me.zhengjie.modules.system.service.dto.UserLoginDto;
@@ -101,7 +101,7 @@ public interface UserService {
      * @param pageable 分页参数
      * @return /
      */
-    APage<UserDto> queryAll(UserQueryCriteria criteria, Pageable pageable);
+    PageResult<UserDto> queryAll(UserQueryCriteria criteria, Pageable pageable);
 
     /**
      * 查询全部不分页

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/UserService.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/UserService.java
@@ -15,6 +15,7 @@
  */
 package me.zhengjie.modules.system.service;
 
+import me.zhengjie.utils.APage;
 import me.zhengjie.modules.system.domain.User;
 import me.zhengjie.modules.system.service.dto.UserDto;
 import me.zhengjie.modules.system.service.dto.UserLoginDto;
@@ -100,7 +101,7 @@ public interface UserService {
      * @param pageable 分页参数
      * @return /
      */
-    Object queryAll(UserQueryCriteria criteria, Pageable pageable);
+    APage<UserDto> queryAll(UserQueryCriteria criteria, Pageable pageable);
 
     /**
      * 查询全部不分页

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictDetailServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictDetailServiceImpl.java
@@ -16,6 +16,7 @@
 package me.zhengjie.modules.system.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import me.zhengjie.utils.APage;
 import me.zhengjie.modules.system.domain.Dict;
 import me.zhengjie.modules.system.domain.DictDetail;
 import me.zhengjie.modules.system.repository.DictRepository;
@@ -32,7 +33,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
-import java.util.Map;
 
 /**
 * @author Zheng Jie
@@ -49,7 +49,7 @@ public class DictDetailServiceImpl implements DictDetailService {
     private final RedisUtils redisUtils;
 
     @Override
-    public Map<String,Object> queryAll(DictDetailQueryCriteria criteria, Pageable pageable) {
+    public APage<DictDetailDto> queryAll(DictDetailQueryCriteria criteria, Pageable pageable) {
         Page<DictDetail> page = dictDetailRepository.findAll((root, criteriaQuery, criteriaBuilder) -> QueryHelp.getPredicate(root,criteria,criteriaBuilder),pageable);
         return PageUtil.toPage(page.map(dictDetailMapper::toDto));
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictDetailServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictDetailServiceImpl.java
@@ -16,7 +16,7 @@
 package me.zhengjie.modules.system.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.modules.system.domain.Dict;
 import me.zhengjie.modules.system.domain.DictDetail;
 import me.zhengjie.modules.system.repository.DictRepository;
@@ -49,7 +49,7 @@ public class DictDetailServiceImpl implements DictDetailService {
     private final RedisUtils redisUtils;
 
     @Override
-    public APage<DictDetailDto> queryAll(DictDetailQueryCriteria criteria, Pageable pageable) {
+    public PageResult<DictDetailDto> queryAll(DictDetailQueryCriteria criteria, Pageable pageable) {
         Page<DictDetail> page = dictDetailRepository.findAll((root, criteriaQuery, criteriaBuilder) -> QueryHelp.getPredicate(root,criteria,criteriaBuilder),pageable);
         return PageUtil.toPage(page.map(dictDetailMapper::toDto));
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictServiceImpl.java
@@ -17,7 +17,7 @@ package me.zhengjie.modules.system.service.impl;
 
 import cn.hutool.core.collection.CollectionUtil;
 import lombok.RequiredArgsConstructor;
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.modules.system.domain.Dict;
 import me.zhengjie.modules.system.service.dto.DictDetailDto;
 import me.zhengjie.modules.system.service.dto.DictQueryCriteria;
@@ -49,7 +49,7 @@ public class DictServiceImpl implements DictService {
     private final RedisUtils redisUtils;
 
     @Override
-    public APage<DictDto> queryAll(DictQueryCriteria dict, Pageable pageable){
+    public PageResult<DictDto> queryAll(DictQueryCriteria dict, Pageable pageable){
         Page<Dict> page = dictRepository.findAll((root, query, cb) -> QueryHelp.getPredicate(root, dict, cb), pageable);
         return PageUtil.toPage(page.map(dictMapper::toDto));
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/DictServiceImpl.java
@@ -17,6 +17,7 @@ package me.zhengjie.modules.system.service.impl;
 
 import cn.hutool.core.collection.CollectionUtil;
 import lombok.RequiredArgsConstructor;
+import me.zhengjie.utils.APage;
 import me.zhengjie.modules.system.domain.Dict;
 import me.zhengjie.modules.system.service.dto.DictDetailDto;
 import me.zhengjie.modules.system.service.dto.DictQueryCriteria;
@@ -48,7 +49,7 @@ public class DictServiceImpl implements DictService {
     private final RedisUtils redisUtils;
 
     @Override
-    public Map<String, Object> queryAll(DictQueryCriteria dict, Pageable pageable){
+    public APage<DictDto> queryAll(DictQueryCriteria dict, Pageable pageable){
         Page<Dict> page = dictRepository.findAll((root, query, cb) -> QueryHelp.getPredicate(root, dict, cb), pageable);
         return PageUtil.toPage(page.map(dictMapper::toDto));
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/JobServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/JobServiceImpl.java
@@ -16,7 +16,7 @@
 package me.zhengjie.modules.system.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.exception.BadRequestException;
 import me.zhengjie.exception.EntityExistException;
 import me.zhengjie.modules.system.domain.Job;
@@ -53,7 +53,7 @@ public class JobServiceImpl implements JobService {
     private final UserRepository userRepository;
 
     @Override
-    public APage<JobDto> queryAll(JobQueryCriteria criteria, Pageable pageable) {
+    public PageResult<JobDto> queryAll(JobQueryCriteria criteria, Pageable pageable) {
         Page<Job> page = jobRepository.findAll((root, criteriaQuery, criteriaBuilder) -> QueryHelp.getPredicate(root,criteria,criteriaBuilder),pageable);
         return PageUtil.toPage(page.map(jobMapper::toDto).getContent(),page.getTotalElements());
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/JobServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/JobServiceImpl.java
@@ -16,6 +16,7 @@
 package me.zhengjie.modules.system.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import me.zhengjie.utils.APage;
 import me.zhengjie.exception.BadRequestException;
 import me.zhengjie.exception.EntityExistException;
 import me.zhengjie.modules.system.domain.Job;
@@ -52,7 +53,7 @@ public class JobServiceImpl implements JobService {
     private final UserRepository userRepository;
 
     @Override
-    public Map<String,Object> queryAll(JobQueryCriteria criteria, Pageable pageable) {
+    public APage<JobDto> queryAll(JobQueryCriteria criteria, Pageable pageable) {
         Page<Job> page = jobRepository.findAll((root, criteriaQuery, criteriaBuilder) -> QueryHelp.getPredicate(root,criteria,criteriaBuilder),pageable);
         return PageUtil.toPage(page.map(jobMapper::toDto).getContent(),page.getTotalElements());
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
@@ -16,6 +16,7 @@
 package me.zhengjie.modules.system.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import me.zhengjie.utils.APage;
 import me.zhengjie.config.FileProperties;
 import me.zhengjie.exception.BadRequestException;
 import me.zhengjie.modules.security.service.OnlineUserService;
@@ -61,7 +62,7 @@ public class UserServiceImpl implements UserService {
     private final UserLoginMapper userLoginMapper;
 
     @Override
-    public Object queryAll(UserQueryCriteria criteria, Pageable pageable) {
+    public APage<UserDto> queryAll(UserQueryCriteria criteria, Pageable pageable) {
         Page<User> page = userRepository.findAll((root, criteriaQuery, criteriaBuilder) -> QueryHelp.getPredicate(root, criteria, criteriaBuilder), pageable);
         return PageUtil.toPage(page.map(userMapper::toDto));
     }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/system/service/impl/UserServiceImpl.java
@@ -16,7 +16,7 @@
 package me.zhengjie.modules.system.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import me.zhengjie.utils.APage;
+import me.zhengjie.utils.PageResult;
 import me.zhengjie.config.FileProperties;
 import me.zhengjie.exception.BadRequestException;
 import me.zhengjie.modules.security.service.OnlineUserService;
@@ -62,7 +62,7 @@ public class UserServiceImpl implements UserService {
     private final UserLoginMapper userLoginMapper;
 
     @Override
-    public APage<UserDto> queryAll(UserQueryCriteria criteria, Pageable pageable) {
+    public PageResult<UserDto> queryAll(UserQueryCriteria criteria, Pageable pageable) {
         Page<User> page = userRepository.findAll((root, criteriaQuery, criteriaBuilder) -> QueryHelp.getPredicate(root, criteria, criteriaBuilder), pageable);
         return PageUtil.toPage(page.map(userMapper::toDto));
     }


### PR DESCRIPTION
1. 增加类 `APage`，并重构 `PageUtils`
2. 调整 `UserController` 的 `查询用户` 接口的返回值类型

我们希望通过在 Swagger 中展示接口的返回值结构，以便减少前后端的沟通成本，并提升接口对接的效率。

![image](https://github.com/elunez/eladmin/assets/38241684/c11e158f-a8e5-4cb0-b302-09f06f984246)

![image](https://github.com/elunez/eladmin/assets/38241684/6072375f-20fb-4247-9b9c-60223c282fc6)
