### PR TITLE
fix(LimitAspect): 修复lua脚本执行结束后，类型转换失败的bug

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/aspect/LimitAspect.java
+++ b/eladmin-common/src/main/java/me/zhengjie/aspect/LimitAspect.java
@@ -71,8 +71,8 @@ public class LimitAspect {
         ImmutableList<Object> keys = ImmutableList.of(StringUtils.join(limit.prefix(), "_", key, "_", request.getRequestURI().replace("/","_")));
 
         String luaScript = buildLuaScript();
-        RedisScript<Number> redisScript = new DefaultRedisScript<>(luaScript, Number.class);
-        Number count = redisTemplate.execute(redisScript, keys, limit.count(), limit.period());
+        RedisScript<Long> redisScript = new DefaultRedisScript<>(luaScript, Long.class);
+        Long count = redisTemplate.execute(redisScript, keys, limit.count(), limit.period());
         if (null != count && count.intValue() <= limit.count()) {
             logger.info("第{}次访问key为 {}，描述为 [{}] 的接口", count, keys, limit.name());
             return joinPoint.proceed();

--- a/eladmin-tools/src/main/java/me/zhengjie/service/impl/EmailServiceImpl.java
+++ b/eladmin-tools/src/main/java/me/zhengjie/service/impl/EmailServiceImpl.java
@@ -86,6 +86,8 @@ public class EmailServiceImpl implements EmailService {
         account.setSslEnable(true);
         // 使用STARTTLS安全连接
         account.setStarttlsEnable(true);
+        // 解决jdk8之后默认禁用部分tls协议，导致邮件发送失败的问题
+        account.setSslProtocols("TLSv1 TLSv1.1 TLSv1.2");
         String content = emailVo.getContent();
         // 发送
         try {


### PR DESCRIPTION
1、测试jdk版本：jdk1.8.0_351、jdk11.0.18
类型转换失败，不能将值转换为Number，用Long进行替代

报错截图：
![image](https://github.com/elunez/eladmin/assets/64514383/c9b218fc-26c7-4210-bf7b-4a02f89599dd)
